### PR TITLE
\r Newline Fix

### DIFF
--- a/lib/csv_sniffer.rb
+++ b/lib/csv_sniffer.rb
@@ -12,7 +12,7 @@ class CsvSniffer
 
     def self.is_quote_enclosed?(filepath)
       begin
-        line = File.open(filepath, &:readline)
+        line = File.open(filepath, binmode: 'rt', encoding: 'bom|utf-8:utf-8', &:readline)
         line.chomp!.strip!
         return line.start_with?('"') && line.end_with?('"') || line.start_with?("'") && line.end_with?("'")
       rescue EOFError
@@ -33,7 +33,7 @@ class CsvSniffer
     def self.get_quote_char(filepath)
       begin
         if is_quote_enclosed?(filepath)
-          line = File.open(filepath, &:readline)
+          line = File.open(filepath, binmode: 'rt', encoding: 'bom|utf-8:utf-8', &:readline)
           line.chomp!.strip!
           return line[0]
         else
@@ -63,7 +63,7 @@ class CsvSniffer
       # to the comma. Unless that delimeter's count is equal to the tab or pipe delimiter's count. In that case we return \t or |
 
       if is_quote_enclosed?(filepath)
-        line = File.open(filepath, &:readline)
+        line = File.open(filepath, binmode: 'rt', encoding: 'bom|utf-8:utf-8', &:readline)
         line.chomp!.strip!
         m = /["'].+?["']([,|;\t])/.match(line)
         if (m)
@@ -72,7 +72,7 @@ class CsvSniffer
       end
 
       lineCount = 0
-      File.foreach(filepath) do |line|
+      File.foreach(filepath, binmode: 'rt', encoding: 'bom|utf-8:utf-8') do |line|
         detectedDelim = max_delim_when_others_are_zero(line)
         if detectedDelim != '0' #=> '0' is a sentinel value that indicates no delim found
           return detectedDelim
@@ -84,7 +84,7 @@ class CsvSniffer
 
       # If I got here I'm going to pick the default by counting the delimiters on the first line and returning the max
       begin
-        line = File.open(filepath, &:readline)
+        line = File.open(filepath, binmode: 'rt', encoding: 'bom|utf-8:utf-8', &:readline)
         freqOfPossibleDelims = get_freq_of_possible_delims(line)
       rescue EOFError
         freqOfPossibleDelims = [0,-1,-1,-1]
@@ -128,14 +128,12 @@ class CsvSniffer
       # Finally, a 'vote' is taken at the end for each column, adding or
       # subtracting from the likelihood of the first row being a header.
       delim = detect_delimiter(filepath)
-      if (delim == "\\t")
-        delim = "\t"
-      end
+      delim = "\t" if delim == "\\t"
 
       headerRow = nil
       lineCount = 0
       columnTypes = Hash.new
-      File.foreach(filepath) do |line|
+      File.foreach(filepath, binmode: 'rt', encoding: 'bom|utf-8:utf-8') do |line|
         if (!headerRow) # assume the first row is a header
           headerRow = line.split(delim)
 

--- a/test/test_csv_sniffer.rb
+++ b/test/test_csv_sniffer.rb
@@ -42,29 +42,35 @@ class CsvSnifferTest < Minitest::Test
   @@file7 = Tempfile.new('file7', binmode: 'wt+')
   @@file7.rewind
 
-  @@file8 = Tempfile.new('file5', binmode: 'wt+')
+  @@file8 = Tempfile.new('file8', binmode: 'wt+')
   @@file8.puts '"Name"|"Phone"|"Age"'
   @@file8.puts '"Doe,,,,,, John"|"555-123-4567"|"31"'
   @@file8.puts '"Jane C. Doe"|"555-000-1234\t"|"30"'
   @@file8.rewind
 
-  @@file9 = Tempfile.new('file5', binmode: 'wt+', encoding: 'utf-16le')
+  @@file9 = Tempfile.new('file9', binmode: 'wt+', encoding: 'utf-16le')
   @@file9.puts UTF_16_BOM + '"Name"|"Phone"|"Age"'.encode('utf-16le')
   @@file9.puts '"Doe,,,,,, John"|"555-123-4567"|"31"'
   @@file9.puts '"Jane C. Doe"|"555-000-1234\t"|"30"'
   @@file9.rewind
 
-  @@file10 = Tempfile.new('file5', binmode: 'wt+', encoding: 'utf-16le')
+  @@file10 = Tempfile.new('file10', binmode: 'wt+', encoding: 'utf-16le')
   @@file10.puts UTF_16_BOM + 'Name;Phone;Age'.encode('utf-16le')
   @@file10.puts '"Doe John";"555-123-4567";31'
   @@file10.puts '"Jane C. Doe";"555-000-1234\t";30'
   @@file10.rewind
+
+  @@file11 = Tempfile.new('file11', binmode: 'wt+')
+  @@file11.print "\"Name\",\"Number\"\rJohn ;;;;;;;; Doe,555-123-4567\r"
+  @@file11.flush
+  @@file11.rewind
 
   def test_file1
     assert_equal ",", CsvSniffer.detect_delimiter(@@file1.path)
     assert_equal false, CsvSniffer.is_quote_enclosed?(@@file1.path)
     assert_equal nil, CsvSniffer.get_quote_char(@@file1.path)
     assert_equal true, CsvSniffer.has_header?(@@file1.path)
+    assert_equal "Name,Number", CsvSniffer.first_line(@@file1.path)
   end
 
   def test_file2
@@ -122,5 +128,13 @@ class CsvSnifferTest < Minitest::Test
     assert_equal false, CsvSniffer.is_quote_enclosed?(@@file10.path)
     assert_equal nil, CsvSniffer.get_quote_char(@@file10.path)
     assert_equal true, CsvSniffer.has_header?(@@file10.path)
+  end
+
+  def test_file11
+    assert_equal "\r", CsvSniffer.detect_endline(@@file11.path)
+    assert_equal ",", CsvSniffer.detect_delimiter(@@file11.path)
+    assert_equal true, CsvSniffer.is_quote_enclosed?(@@file11.path)
+    assert_equal '"', CsvSniffer.get_quote_char(@@file11.path)
+    assert_equal true, CsvSniffer.has_header?(@@file11.path)
   end
 end

--- a/test/test_csv_sniffer.rb
+++ b/test/test_csv_sniffer.rb
@@ -3,43 +3,62 @@ require 'tempfile'
 require 'csv_sniffer'
 
 class CsvSnifferTest < Minitest::Test
+  UTF_16_BOM = "\xFF\xFE".force_encoding('utf-16le')
 
-  @@file1 = Tempfile.new('file1')
+  @@file1 = Tempfile.new('file1', binmode: 'wt+')
   @@file1.puts "Name,Number"
   @@file1.puts "John Doe,555-123-4567"
   @@file1.puts "Jane C. Doe,555-000-1234"
   @@file1.rewind
 
-  @@file2 = Tempfile.new('file2')
+  @@file2 = Tempfile.new('file2', binmode: 'wt+')
   @@file2.puts "'Name' |'Number'\t"
   @@file2.puts "'John Doe'|'555-123-4567'"
   @@file2.puts "'Jane C. Doe'|'555-000-1234'"
   @@file2.rewind
 
-  @@file3 = Tempfile.new('file3')
+  @@file3 = Tempfile.new('file3', binmode: 'wt+')
   @@file3.puts "John Doe;555-123-4567;Good\tdude"
   @@file3.puts "Jane C. Doe;555-000-1234   ; Great gal"
   @@file3.puts "John Smith;555-999-1234;Don't know about him"
   @@file3.rewind
 
-  @@file4 = Tempfile.new('file4')
+  @@file4 = Tempfile.new('file4', binmode: 'wt+')
   @@file4.puts "Doe, John\t555-123-4567"
   @@file4.puts "Jane C. Doe\t555-000-1234\t"
   @@file4.rewind
 
-  @@file5 = Tempfile.new('file5')
+  @@file5 = Tempfile.new('file5', binmode: 'wt+')
   @@file5.puts '"Doe,,,,,, John"|"555-123-4567"'
   @@file5.puts '"Jane C. Doe"|"555-000-1234\t"'
   @@file5.rewind
 
-  @@file6 = Tempfile.new('file6')
+  @@file6 = Tempfile.new('file6', binmode: 'wt+')
   @@file6.puts 'Name|Phone No.|Age'
   @@file6.puts 'Doe, John|555-123-4567|31'
   @@file6.puts 'Doe, Jane C. |555-000-1234|30'
   @@file6.rewind
 
-  @@file7 = Tempfile.new('file7')
+  @@file7 = Tempfile.new('file7', binmode: 'wt+')
   @@file7.rewind
+
+  @@file8 = Tempfile.new('file5', binmode: 'wt+')
+  @@file8.puts '"Name"|"Phone"|"Age"'
+  @@file8.puts '"Doe,,,,,, John"|"555-123-4567"|"31"'
+  @@file8.puts '"Jane C. Doe"|"555-000-1234\t"|"30"'
+  @@file8.rewind
+
+  @@file9 = Tempfile.new('file5', binmode: 'wt+', encoding: 'utf-16le')
+  @@file9.puts UTF_16_BOM + '"Name"|"Phone"|"Age"'.encode('utf-16le')
+  @@file9.puts '"Doe,,,,,, John"|"555-123-4567"|"31"'
+  @@file9.puts '"Jane C. Doe"|"555-000-1234\t"|"30"'
+  @@file9.rewind
+
+  @@file10 = Tempfile.new('file5', binmode: 'wt+', encoding: 'utf-16le')
+  @@file10.puts UTF_16_BOM + 'Name;Phone;Age'.encode('utf-16le')
+  @@file10.puts '"Doe John";"555-123-4567";31'
+  @@file10.puts '"Jane C. Doe";"555-000-1234\t";30'
+  @@file10.rewind
 
   def test_file1
     assert_equal ",", CsvSniffer.detect_delimiter(@@file1.path)
@@ -82,5 +101,26 @@ class CsvSnifferTest < Minitest::Test
     assert_equal false, CsvSniffer.has_header?(@@file7.path)
     assert_equal nil, CsvSniffer.get_quote_char(@@file7.path)
     assert_equal ",", CsvSniffer.detect_delimiter(@@file7.path)
+  end
+
+  def test_file8
+    assert_equal "|", CsvSniffer.detect_delimiter(@@file8.path)
+    assert_equal true, CsvSniffer.is_quote_enclosed?(@@file8.path)
+    assert_equal '"', CsvSniffer.get_quote_char(@@file8.path)
+    assert_equal true, CsvSniffer.has_header?(@@file8.path)
+  end
+
+  def test_file9
+    assert_equal "|", CsvSniffer.detect_delimiter(@@file9.path)
+    assert_equal true, CsvSniffer.is_quote_enclosed?(@@file9.path)
+    assert_equal '"', CsvSniffer.get_quote_char(@@file9.path)
+    assert_equal true, CsvSniffer.has_header?(@@file9.path)
+  end
+
+  def test_file10
+    assert_equal ";", CsvSniffer.detect_delimiter(@@file10.path)
+    assert_equal false, CsvSniffer.is_quote_enclosed?(@@file10.path)
+    assert_equal nil, CsvSniffer.get_quote_char(@@file10.path)
+    assert_equal true, CsvSniffer.has_header?(@@file10.path)
   end
 end


### PR DESCRIPTION
Files with \r newlines would crash. Files with \r\n newlines would inappropriately treat the whole file as the first row. These issues are fixed and tested.

Also refactored File operations to DRY up interactions.

Built on top of https://github.com/tim-ojo/csv_sniffer/pull/2